### PR TITLE
Create iframe automatically if needed when deep linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,11 @@ You must create a `.storybook` folder with a `main.js` file inside of it, where 
 
 To enable switching between devices, you must also create a `preview.js` file in your `.storybook` folder, with the [contents found here](examples/android-material-ui/.storybook/preview.js)
 
-If you are using deep linking, your `.storybook` folder MUST also have a `preview-body.html` that declares an iframe element with the id `appetize-iframe`. One example of this file [can be found here](examples/android-material-ui-deep-link/.storybook/preview-body.html). There is currently an issue where the appetize iframe still gets displayed when in the `docs` panel. A temporary workaround is to create a `preview-head.html` file in your `.storybook` folder with the following contents:
+If you are using deep linking, your `.storybook` folder should also have a `preview-body.html` that declares the following contents:
 ```html
 <style>
-  #docs-root {
-    position: absolute;
-    z-index: 1;
-    top: 0;
+  #root[hidden="true"] ~ #appetize-iframe {
+    display: none;
   }
 </style>
 ```

--- a/examples/android-material-ui-deep-link/.storybook/preview-body.html
+++ b/examples/android-material-ui-deep-link/.storybook/preview-body.html
@@ -1,11 +1,5 @@
-<div id="custom-root">
-  <iframe
-      title="Example appetize-embed"
-      src="about:blank"
-      width="1400px" 
-      height="888px" 
-      scrolling="no"
-      id="appetize-iframe"
-      frameBorder="0">
-  </iframe>
-</div>
+<style>
+  #root[hidden="true"] ~ #appetize-iframe {
+    display: none;
+  }
+</style>

--- a/examples/android-material-ui-deep-link/.storybook/preview-head.html
+++ b/examples/android-material-ui-deep-link/.storybook/preview-head.html
@@ -1,7 +1,0 @@
-<style>
-  #docs-root {
-    position: absolute;
-    z-index: 1;
-    top: 0;
-  }
-</style>

--- a/examples/controls/.storybook/preview-body.html
+++ b/examples/controls/.storybook/preview-body.html
@@ -1,11 +1,5 @@
-<div id="custom-root">
-  <iframe
-      title="Example appetize-embed"
-      src="about:blank"
-      width="1400px" 
-      height="888px" 
-      scrolling="no"
-      id="appetize-iframe"
-      frameBorder="0">
-  </iframe>
-</div>
+<style>
+  #root[hidden="true"] ~ #appetize-iframe {
+    display: none;
+  }
+</style>

--- a/examples/controls/.storybook/preview-head.html
+++ b/examples/controls/.storybook/preview-head.html
@@ -1,7 +1,0 @@
-<style>
-  #docs-root {
-    position: absolute;
-    z-index: 1;
-    top: 0;
-  }
-</style>

--- a/packages/appetize-utils/src/constants.ts
+++ b/packages/appetize-utils/src/constants.ts
@@ -1,0 +1,1 @@
+export const APPETIZE_IFRAME_ID = "appetize-iframe";

--- a/packages/appetize-utils/src/iframeUtils.ts
+++ b/packages/appetize-utils/src/iframeUtils.ts
@@ -5,8 +5,8 @@ const getInnerDocument = (): HTMLDocument => {
         "storybook-preview-iframe"
     ) as HTMLIFrameElement;
     const innerDoc = storybookFrame
-        ? (storybookFrame.contentDocument ||
-          storybookFrame.contentWindow?.document)
+        ? storybookFrame.contentDocument ||
+          storybookFrame.contentWindow?.document
         : document;
     if (!innerDoc) {
         throw new Error("The inner document was not found");

--- a/packages/appetize-utils/src/iframeUtils.ts
+++ b/packages/appetize-utils/src/iframeUtils.ts
@@ -1,22 +1,42 @@
-export const getAppetizeIframe = (): HTMLIFrameElement | null => {
+import { APPETIZE_IFRAME_ID } from "./constants";
+
+const getInnerDocument = (): HTMLDocument => {
     const storybookFrame = document.getElementById(
         "storybook-preview-iframe"
     ) as HTMLIFrameElement;
     const innerDoc = storybookFrame
-        ? storybookFrame.contentDocument ||
-          storybookFrame.contentWindow?.document
+        ? (storybookFrame.contentDocument ||
+          storybookFrame.contentWindow?.document)
         : document;
     if (!innerDoc) {
-        console.warn("The inner document was not found");
-        return null;
+        throw new Error("The inner document was not found");
     }
 
+    return innerDoc;
+};
+
+export const createAppetizeIframe = (): HTMLIFrameElement => {
+    const innerDoc = getInnerDocument();
+    const iframe = innerDoc.createElement("iframe");
+    iframe.id = APPETIZE_IFRAME_ID;
+    iframe.style.border = "0";
+    iframe.style.overflow = "hidden";
+    iframe.style.width = "800px";
+    iframe.style.height = "1400px";
+    iframe.src = "about:blank";
+    iframe.title = "appetize-embed";
+    innerDoc.body.appendChild(iframe);
+    return iframe;
+};
+
+export const getAppetizeIframe = (): HTMLIFrameElement | null => {
+    const innerDoc = getInnerDocument();
     const appetizeFrame = innerDoc.getElementById(
-        "appetize-iframe"
+        APPETIZE_IFRAME_ID
     ) as HTMLIFrameElement;
     if (!appetizeFrame) {
-        console.warn("The appetize.io iframe was not found");
-        return null;
+        console.warn("The appetize.io iframe was not found. Creating one");
+        return createAppetizeIframe();
     }
 
     return appetizeFrame;

--- a/packages/native-components/src/DeepLinkRenderer.tsx
+++ b/packages/native-components/src/DeepLinkRenderer.tsx
@@ -23,7 +23,5 @@ export default (props: RendererProps): React.ReactElement => {
         openDeepLink(appetizeUrl, deepLinkBaseUrl, storyParamsWithKnobs);
     }, [device, JSON.stringify(storyParamsWithKnobs), deepLinkBaseUrl, apiKey]);
 
-    return (
-        <div />
-    );
+    return <div />;
 };

--- a/packages/native-components/src/DeepLinkRenderer.tsx
+++ b/packages/native-components/src/DeepLinkRenderer.tsx
@@ -10,6 +10,7 @@ export default (props: RendererProps): React.ReactElement => {
     }
 
     const device = useDevice(platform);
+    const storyParamsWithKnobs = { ...storyParams, ...knobs };
     React.useEffect(() => {
         const appetizeUrl = getAppetizeUrl(
             {},
@@ -19,9 +20,10 @@ export default (props: RendererProps): React.ReactElement => {
             apiKey
         );
 
-        const storyParamsWithKnobs = { ...storyParams, ...knobs };
         openDeepLink(appetizeUrl, deepLinkBaseUrl, storyParamsWithKnobs);
-    }, [device, storyParams, knobs, deepLinkBaseUrl, apiKey]);
+    }, [device, JSON.stringify(storyParamsWithKnobs), deepLinkBaseUrl, apiKey]);
 
-    return <div />;
+    return (
+        <div />
+    );
 };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.12-canary.22.306.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@0.2.12-canary.22.306.0
  npm install @storybook/native-android-material-example@0.2.12-canary.22.306.0
  npm install @storybook/native-controls-example@0.2.12-canary.22.306.0
  npm install @storybook/native-flutter-example@0.2.12-canary.22.306.0
  npm install @storybook/native-ios-example@0.2.12-canary.22.306.0
  npm install @storybook/appetize-utils@0.2.12-canary.22.306.0
  npm install @storybook/native-addon@0.2.12-canary.22.306.0
  npm install @storybook/native-components@0.2.12-canary.22.306.0
  npm install @storybook/native-devices@0.2.12-canary.22.306.0
  npm install @storybook/native-types@0.2.12-canary.22.306.0
  npm install @storybook/native@0.2.12-canary.22.306.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@0.2.12-canary.22.306.0
  yarn add @storybook/native-android-material-example@0.2.12-canary.22.306.0
  yarn add @storybook/native-controls-example@0.2.12-canary.22.306.0
  yarn add @storybook/native-flutter-example@0.2.12-canary.22.306.0
  yarn add @storybook/native-ios-example@0.2.12-canary.22.306.0
  yarn add @storybook/appetize-utils@0.2.12-canary.22.306.0
  yarn add @storybook/native-addon@0.2.12-canary.22.306.0
  yarn add @storybook/native-components@0.2.12-canary.22.306.0
  yarn add @storybook/native-devices@0.2.12-canary.22.306.0
  yarn add @storybook/native-types@0.2.12-canary.22.306.0
  yarn add @storybook/native@0.2.12-canary.22.306.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
