### PR TITLE
Add iOS deep linking example, testing github pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,9 @@ jobs:
           name: Auto Shipit
           command: |
             yarn release
+            if [ "${CIRCLE_BRANCH}" == "master" ];
+              yarn release:storybook
+            fi
 workflows:
   test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,9 +115,7 @@ jobs:
           name: Auto Shipit
           command: |
             yarn release
-            if [ "${CIRCLE_BRANCH}" == "master" ];
-              yarn release:storybook
-            fi
+            bash ./deploy.sh
 workflows:
   test:
     jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,8 @@ project.xcworkspace
 fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
+.dart_tool
+.packages
 
 storybook-static/
 *.log

--- a/README.md
+++ b/README.md
@@ -29,9 +29,14 @@ If you wanted to use those query parameters, your application would need to pars
 *You do not need to exactly follow the above example for your query parameters! Your query parameters can have any information that you want.*
 
 Examples of parsing query parameters:
- - [Android - parsing intents](examples/android-material-ui/app/app/src/main/java/com/intuit/august2020/storybookdemoapp/MainActivity.kt#L32)
+ - [Android](examples/android-material-ui/app/app/src/main/java/com/intuit/august2020/storybookdemoapp/MainActivity.kt#L32)
+ - [iOS](examples/ios-material-ui/app/iOSStoryBookDemo/iOSStoryBookDemo/AppDelegate.swift#L83)
 
-You can read more about how to setup deep linking for Android [here](https://developer.android.com/training/app-links/deep-linking). Deep linking should also work on iOS and Flutter, but there are no examples for this yet.
+You can read more about how to setup deep linking for Android [here](https://developer.android.com/training/app-links/deep-linking).
+
+For iOS, [this article](https://medium.com/wolox/ios-deep-linking-url-scheme-vs-universal-links-50abd3802f97) explains how to set up deep linking. Note that for the examples in this repo, we use URL schemes instead of Universal Links since they are simpler to set up.
+
+Deep linking should also work on Flutter, but there are no examples for this yet.
 
 ### 2. Launch Parameters
 appetize.io allows you to pass in custom launch parameters which will be sent to your mobile application when it first starts up. In your application, you must create a handler that determines what to render based on what those launch parameters are.  
@@ -77,6 +82,7 @@ Examples of how to use this module as both a build tool and as a component libra
 
 - [Android storybook with deep linking](https://5f99b8bcfe88ac0022fcf70e-ephawpkuvg.chromatic.com/)
 - [Android storybook with controls](https://5f99b8bcfe88ac0022fcf70e-xjyrunjvpo.chromatic.com/)
+TODO: iOS deep link
 - [Android storybook with launch parameters](https://5f99b8bcfe88ac0022fcf70e-uqmnpmxiue.chromatic.com/)
 - [Flutter storybook with launch parameters](https://5f99b8bcfe88ac0022fcf70e-zkykyigdhc.chromatic.com/)
 - [iOS storybook with launch parameters](https://5f99b8bcfe88ac0022fcf70e-bkrwusstqb.chromatic.com/)

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,3 @@
+if [ "${CIRCLE_BRANCH}" == "master" ];
+  yarn release:storybook
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,3 @@
-if [ "${CIRCLE_BRANCH}" == "master" ];
+if [ "${CIRCLE_BRANCH}" == "master" ]; then
   yarn release:storybook
 fi

--- a/examples/android-material-ui-deep-link/package.json
+++ b/examples/android-material-ui-deep-link/package.json
@@ -10,8 +10,9 @@
     "Vanya Sehgal <vanya_sehgal@intuit.com>"
   ],
   "scripts": {
-    "start": "node ./generate.js && yarn start-storybook -p 53743",
-    "build:storybook": "node ./generate.js && yarn build-storybook"
+    "start": "yarn build:stories && yarn start-storybook -p 53743",
+    "build:storybook": "yarn build:stories && yarn build-storybook",
+    "build:stories": "node ./generate.js"
   },
   "keywords": [],
   "dependencies": {

--- a/examples/android-material-ui/package.json
+++ b/examples/android-material-ui/package.json
@@ -10,8 +10,9 @@
     "Vanya Sehgal <vanya_sehgal@intuit.com>"
   ],
   "scripts": {
-    "start": "node ./generate.js && yarn start-storybook",
-    "build:storybook": "node ./generate.js && yarn build-storybook"
+    "start": "yarn build:stories && yarn start-storybook",
+    "build:storybook": "yarn build:stories && yarn build-storybook",
+    "build:stories": "node ./generate.js"
   },
   "keywords": [],
   "dependencies": {

--- a/examples/flutter/app/pubspec.lock
+++ b/examples/flutter/app/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0-nullsafety.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,21 +73,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.3"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,55 +99,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.3"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.10.0-110 <2.11.0"

--- a/examples/flutter/package.json
+++ b/examples/flutter/package.json
@@ -10,8 +10,9 @@
     "Thomas Baker <thomas_baker@intuit.com>"
   ],
   "scripts": {
-    "start": "node ./generate.js && yarn start-storybook",
-    "build:storybook": "node ./generate.js && yarn build-storybook"
+    "start": "yarn build:storiess && yarn start-storybook",
+    "build:storybook": "yarn build:stories && yarn build-storybook",
+    "build:stories": "node ./generate.js"
   },
   "keywords": [],
   "dependencies": {

--- a/examples/ios-material-ui-deep-link/.storybook/main.js
+++ b/examples/ios-material-ui-deep-link/.storybook/main.js
@@ -1,0 +1,8 @@
+module.exports = {
+    stories: ["../src/*.stories.jsx"],
+    addons: [
+        "@storybook/addon-docs",
+        "@storybook/addon-controls",
+        "@storybook/native-addon/dist/register.js"
+    ]
+};

--- a/examples/ios-material-ui-deep-link/.storybook/preview-body.html
+++ b/examples/ios-material-ui-deep-link/.storybook/preview-body.html
@@ -1,0 +1,5 @@
+<style>
+  #root[hidden="true"] ~ #appetize-iframe {
+    display: none;
+  }
+</style>

--- a/examples/ios-material-ui-deep-link/.storybook/preview.js
+++ b/examples/ios-material-ui-deep-link/.storybook/preview.js
@@ -1,0 +1,3 @@
+import { DeviceDecorator } from "@storybook/native-addon";
+
+export const decorators = [DeviceDecorator];

--- a/examples/ios-material-ui-deep-link/app/README.md
+++ b/examples/ios-material-ui-deep-link/app/README.md
@@ -1,0 +1,1 @@
+This application is the same as the one [here](../../ios-material-ui/app)

--- a/examples/ios-material-ui-deep-link/package.json
+++ b/examples/ios-material-ui-deep-link/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@storybook/native-ios-example-deep-link",
+  "version": "1.0.0",
+  "private": true,
+  "description": "An iOS demo app for storybook native",
+  "repository": "",
+  "author": "Adil Malik <Adil_Malik@intuit.com>",
+  "license": "MIT",
+  "contributors": [
+    "Adil Malik <Adil_Malik@intuit.com>"
+  ],
+  "scripts": {
+    "start": "yarn start-storybook",
+    "build:storybook": "yarn build-storybook"
+  },
+  "keywords": [],
+  "dependencies": {
+    "@storybook/native": "link:../../packages/native",
+    "@storybook/native-addon": "link:../../packages/native-addon"
+  }
+}

--- a/examples/ios-material-ui-deep-link/src/button.stories.jsx
+++ b/examples/ios-material-ui-deep-link/src/button.stories.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Description } from "@storybook/addon-docs/blocks";
+import { EmulatorRenderer } from "@storybook/native-components";
+
+export default {
+    title: "Button"
+};
+
+export const Example = (props) => {
+    return (
+        <EmulatorRenderer
+            apiKey="yc0e33432655wbjnnnemyghhxm"
+            platform="ios"
+            storyParams={{ component: "button" }}
+            deepLinkBaseUrl="sb-native://deep.link"
+            knobs={props}
+        />
+    );
+};
+
+Example.parameters = {
+    docs: {
+        page: () => <Description markdown={undefined} />
+    }
+};

--- a/examples/ios-material-ui-deep-link/src/floatingbutton.stories.jsx
+++ b/examples/ios-material-ui-deep-link/src/floatingbutton.stories.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Description } from "@storybook/addon-docs/blocks";
+import { EmulatorRenderer } from "@storybook/native-components";
+
+export default {
+    title: "FloatingButton"
+};
+
+export const Example = (props) => {
+    return (
+        <EmulatorRenderer
+            apiKey="yc0e33432655wbjnnnemyghhxm"
+            platform="ios"
+            storyParams={{ component: "floatingbutton" }}
+            deepLinkBaseUrl="sb-native://deep.link"
+            knobs={props}
+        />
+    );
+};
+
+Example.parameters = {
+    docs: {
+        page: () => <Description markdown={undefined} />
+    }
+};

--- a/examples/ios-material-ui-deep-link/src/slider.stories.jsx
+++ b/examples/ios-material-ui-deep-link/src/slider.stories.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Description } from "@storybook/addon-docs/blocks";
+import { EmulatorRenderer } from "@storybook/native-components";
+
+export default {
+    title: "Slider"
+};
+
+export const Example = (props) => {
+    return (
+        <EmulatorRenderer
+            apiKey="yc0e33432655wbjnnnemyghhxm"
+            platform="ios"
+            storyParams={{ component: "slider" }}
+            deepLinkBaseUrl="sb-native://deep.link"
+            knobs={props}
+        />
+    );
+};
+
+Example.parameters = {
+    docs: {
+        page: () => <Description markdown={undefined} />
+    }
+};

--- a/examples/ios-material-ui-deep-link/src/spinner.stories.jsx
+++ b/examples/ios-material-ui-deep-link/src/spinner.stories.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Description } from "@storybook/addon-docs/blocks";
+import { EmulatorRenderer } from "@storybook/native-components";
+
+export default {
+    title: "Spinner"
+};
+
+export const Example = (props) => {
+    return (
+        <EmulatorRenderer
+            apiKey="yc0e33432655wbjnnnemyghhxm"
+            platform="ios"
+            storyParams={{ component: "spinner" }}
+            deepLinkBaseUrl="sb-native://deep.link"
+            knobs={props}
+        />
+    );
+};
+
+Example.parameters = {
+    docs: {
+        page: () => <Description markdown={undefined} />
+    }
+};

--- a/examples/ios-material-ui-deep-link/src/textfield.stories.jsx
+++ b/examples/ios-material-ui-deep-link/src/textfield.stories.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Description } from "@storybook/addon-docs/blocks";
+import { EmulatorRenderer } from "@storybook/native-components";
+
+export default {
+    title: "TextField"
+};
+
+export const Example = (props) => {
+    return (
+        <EmulatorRenderer
+            apiKey="yc0e33432655wbjnnnemyghhxm"
+            platform="ios"
+            storyParams={{ component: "textfield" }}
+            deepLinkBaseUrl="sb-native://deep.link"
+            knobs={props}
+        />
+    );
+};
+
+Example.parameters = {
+    docs: {
+        page: () => <Description markdown={undefined} />
+    }
+};

--- a/examples/ios-material-ui/app/iOSStoryBookDemo/iOSStoryBookDemo.xcodeproj/xcshareddata/xcschemes/iOSStoryBookDemo.xcscheme
+++ b/examples/ios-material-ui/app/iOSStoryBookDemo/iOSStoryBookDemo.xcodeproj/xcshareddata/xcschemes/iOSStoryBookDemo.xcscheme
@@ -31,7 +31,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/examples/ios-material-ui/app/iOSStoryBookDemo/iOSStoryBookDemo/AppDelegate.swift
+++ b/examples/ios-material-ui/app/iOSStoryBookDemo/iOSStoryBookDemo/AppDelegate.swift
@@ -80,6 +80,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
     
+    func application(_ app: UIApplication, open url: URL,
+                     options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        if let scheme = url.scheme,
+            scheme.localizedCaseInsensitiveCompare("sb-native") == .orderedSame,
+            let view = url.host {
+            
+            var parameters: [String: String] = [:]
+            URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems?.forEach {
+                parameters[$0.name] = $0.value
+            }
+            
+            launchGalleryFromAppetize(parameters["component"]!)
+        }
+        return true
+    }
+    
     func launchGalleryFromAppetize(_ launchOption: String) {
         var launchOption = launchOption
         if launchOption.isEmpty {

--- a/examples/ios-material-ui/app/iOSStoryBookDemo/iOSStoryBookDemo/Info.plist
+++ b/examples/ios-material-ui/app/iOSStoryBookDemo/iOSStoryBookDemo/Info.plist
@@ -16,6 +16,19 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>Storybook Native</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>sb-native</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/examples/ios-material-ui/package.json
+++ b/examples/ios-material-ui/package.json
@@ -10,8 +10,9 @@
     "Jay Unnikrishn <Jayakrishnan_Unnikrishnan@intuit.com>"
   ],
   "scripts": {
-    "start": "node ./generate.js && yarn start-storybook",
-    "build:storybook": "node ./generate.js && yarn build-storybook"
+    "start": "yarn build:stories && yarn start-storybook",
+    "build:storybook": "yarn build:stories && yarn build-storybook",
+    "build:stories": "node ./generate.js"
   },
   "keywords": [],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
   "scripts": {
     "build": "lerna run build --stream",
     "build:storybook": "lerna run build:storybook --stream",
+    "build:stories": "lerna run build:stories --stream",
     "lint": "eslint --ext .ts --ext .tsx .",
     "prettier": "prettier './**/*.(ts|tsx|js|jsx)'",
     "test": "echo Test",
-    "release": "auto shipit && yarn release:storybook",
-    "release:storybook": "storybook-to-ghpages --packages examples"
+    "release": "auto shipit",
+    "release:storybook": "yarn build:stories && storybook-to-ghpages --packages examples"
   },
   "devDependencies": {
     "@auto-it/all-contributors": "10.0.2",

--- a/package.json
+++ b/package.json
@@ -28,13 +28,15 @@
     "lint": "eslint --ext .ts --ext .tsx .",
     "prettier": "prettier './**/*.(ts|tsx|js|jsx)'",
     "test": "echo Test",
-    "release": "auto shipit"
+    "release": "auto shipit && yarn release:storybook",
+    "release:storybook": "storybook-to-ghpages -- --packages examples"
   },
   "devDependencies": {
     "@auto-it/all-contributors": "10.0.2",
     "@auto-it/conventional-commits": "10.0.2",
     "@auto-it/first-time-contributor": "10.0.2",
     "@auto-it/released": "10.0.2",
+    "@storybook/storybook-deployer": "^2.8.7",
     "@typescript-eslint/eslint-plugin": "4.6.0",
     "@typescript-eslint/parser": "4.6.0",
     "auto": "10.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prettier": "prettier './**/*.(ts|tsx|js|jsx)'",
     "test": "echo Test",
     "release": "auto shipit && yarn release:storybook",
-    "release:storybook": "storybook-to-ghpages -- --packages examples"
+    "release:storybook": "storybook-to-ghpages --packages examples"
   },
   "devDependencies": {
     "@auto-it/all-contributors": "10.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2629,7 +2629,7 @@
     util-deprecate "^1.0.2"
 
 "@storybook/appetize-utils@link:packages/appetize-utils":
-  version "0.2.10"
+  version "1.0.0"
 
 "@storybook/channel-postmessage@6.1.11":
   version "6.1.11"
@@ -2833,7 +2833,7 @@
     lodash "^4.17.15"
 
 "@storybook/native-addon@link:packages/native-addon":
-  version "0.2.10"
+  version "1.0.0"
   dependencies:
     "@storybook/addons" "^6.0.6"
     "@storybook/api" "^6.0.6"
@@ -2847,7 +2847,7 @@
     react-dom "^16.13.1"
 
 "@storybook/native-components@link:packages/native-components":
-  version "0.2.10"
+  version "1.0.0"
   dependencies:
     "@storybook/appetize-utils" "link:packages/appetize-utils"
     "@storybook/native-devices" "link:packages/native-devices"
@@ -2856,17 +2856,17 @@
     react-dom "^16.13.1"
 
 "@storybook/native-devices@link:packages/native-devices":
-  version "0.2.10"
+  version "1.0.0"
   dependencies:
     "@storybook/native-types" "link:packages/native-types"
     react "^16.13.1"
     react-dom "^16.13.1"
 
 "@storybook/native-types@link:packages/native-types":
-  version "0.2.10"
+  version "1.0.0"
 
 "@storybook/native@link:packages/native":
-  version "0.2.10"
+  version "1.0.0"
   dependencies:
     "@storybook/addon-controls" "^6.0.6"
     "@storybook/addon-docs" "^6.0.6"
@@ -2966,6 +2966,17 @@
     prettier "~2.0.5"
     regenerator-runtime "^0.13.7"
     source-map "^0.7.3"
+
+"@storybook/storybook-deployer@^2.8.7":
+  version "2.8.7"
+  resolved "https://registry.yarnpkg.com/@storybook/storybook-deployer/-/storybook-deployer-2.8.7.tgz#c1eed33d03bd9267f884c60eea8e03dc3261ec11"
+  integrity sha512-O0hKHV6hg93fPMvKGC5M/sd7KTL473+SzMKm+WZNVEyLEfXXcVU+Ts9/VL1IhmC1P2A8Bg9oBnkcPqAqjAN46w==
+  dependencies:
+    git-url-parse "^11.1.2"
+    glob "^7.1.3"
+    parse-repo "^1.0.4"
+    shelljs "^0.8.1"
+    yargs "^15.0.0"
 
 "@storybook/theming@6.1.11":
   version "6.1.11"
@@ -10576,6 +10587,11 @@ parse-path@^4.0.0:
     is-ssh "^1.3.0"
     protocols "^1.4.0"
 
+parse-repo@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/parse-repo/-/parse-repo-1.0.4.tgz#74b91d2cb8675d11b99976a0065f6ce17fa1bcc8"
+  integrity sha1-dLkdLLhnXRG5mXagBl9s4X+hvMg=
+
 parse-url@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-5.0.2.tgz#856a3be1fcdf78dc93fc8b3791f169072d898b59"
@@ -12211,7 +12227,7 @@ shell-quote@1.7.2:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
 
-shelljs@^0.8.3, shelljs@^0.8.4:
+shelljs@^0.8.1, shelljs@^0.8.3, shelljs@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
   integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
@@ -14008,7 +14024,7 @@ yargs@^14.2.2:
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
 
-yargs@^15.0.1:
+yargs@^15.0.0, yargs@^15.0.1:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.1-canary.24.347.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@1.0.1-canary.24.347.0
  npm install @storybook/native-android-material-example@1.0.1-canary.24.347.0
  npm install @storybook/native-controls-example@1.0.1-canary.24.347.0
  npm install @storybook/native-flutter-example@1.0.1-canary.24.347.0
  npm install @storybook/native-ios-example-deep-link@1.0.1-canary.24.347.0
  npm install @storybook/native-ios-example@1.0.1-canary.24.347.0
  npm install @storybook/appetize-utils@1.0.1-canary.24.347.0
  npm install @storybook/native-addon@1.0.1-canary.24.347.0
  npm install @storybook/native-components@1.0.1-canary.24.347.0
  npm install @storybook/native-devices@1.0.1-canary.24.347.0
  npm install @storybook/native-types@1.0.1-canary.24.347.0
  npm install @storybook/native@1.0.1-canary.24.347.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@1.0.1-canary.24.347.0
  yarn add @storybook/native-android-material-example@1.0.1-canary.24.347.0
  yarn add @storybook/native-controls-example@1.0.1-canary.24.347.0
  yarn add @storybook/native-flutter-example@1.0.1-canary.24.347.0
  yarn add @storybook/native-ios-example-deep-link@1.0.1-canary.24.347.0
  yarn add @storybook/native-ios-example@1.0.1-canary.24.347.0
  yarn add @storybook/appetize-utils@1.0.1-canary.24.347.0
  yarn add @storybook/native-addon@1.0.1-canary.24.347.0
  yarn add @storybook/native-components@1.0.1-canary.24.347.0
  yarn add @storybook/native-devices@1.0.1-canary.24.347.0
  yarn add @storybook/native-types@1.0.1-canary.24.347.0
  yarn add @storybook/native@1.0.1-canary.24.347.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
