### PR TITLE
Fix not navigating back to prev story after changing devices

### DIFF
--- a/packages/appetize-utils/src/sessionUtils.ts
+++ b/packages/appetize-utils/src/sessionUtils.ts
@@ -5,17 +5,20 @@ interface IncomingMessage {
     data: string;
 }
 
-let lastMessage: Message | null = null;
+let lastUrlMessage: Message | null = null;
 let connected = false;
 
 export const sendMessage = (message: Message, requireConnection?: boolean) => {
     const appetizeFrame = getAppetizeIframe();
+    if (typeof message === "object" && message.type === "url") {
+        lastUrlMessage = message;
+    }
+
     if (
         !appetizeFrame ||
         !appetizeFrame.contentWindow ||
         (!connected && requireConnection)
     ) {
-        lastMessage = message;
         return;
     }
 
@@ -25,10 +28,13 @@ export const sendMessage = (message: Message, requireConnection?: boolean) => {
 const messageEventHandler = (event: IncomingMessage) => {
     if (event.data === "firstFrameReceived") {
         connected = true;
-        if (lastMessage) {
-            sendMessage(lastMessage);
-            lastMessage = null;
-        }
+
+        // small delay because appetize sometimes will not navigate immediately
+        setTimeout(() => {
+            if (lastUrlMessage) {
+                sendMessage(lastUrlMessage);
+            }
+        }, 300);
     } else if (event.data === "sessionEnded") {
         connected = false;
     }

--- a/packages/native-components/src/DeepLinkRenderer.tsx
+++ b/packages/native-components/src/DeepLinkRenderer.tsx
@@ -5,11 +5,12 @@ import { RendererProps } from "./types";
 
 export default (props: RendererProps): React.ReactElement => {
     const { apiKey, platform, knobs, storyParams, deepLinkBaseUrl } = props;
+    const device = useDevice(platform);
+
     if (!deepLinkBaseUrl) {
         throw new Error("No deep link base url was specified");
     }
 
-    const device = useDevice(platform);
     const storyParamsWithKnobs = { ...storyParams, ...knobs };
     React.useEffect(() => {
         const appetizeUrl = getAppetizeUrl(


### PR DESCRIPTION
Closes #20 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.5-canary.34.459.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@1.0.5-canary.34.459.0
  npm install @storybook/native-android-material-example@1.0.5-canary.34.459.0
  npm install @storybook/native-controls-example@1.0.5-canary.34.459.0
  npm install @storybook/native-flutter-example@1.0.5-canary.34.459.0
  npm install @storybook/native-ios-example-deep-link@1.0.5-canary.34.459.0
  npm install @storybook/native-ios-example@1.0.5-canary.34.459.0
  npm install @storybook/appetize-utils@1.0.5-canary.34.459.0
  npm install @storybook/native-addon@1.0.5-canary.34.459.0
  npm install @storybook/native-components@1.0.5-canary.34.459.0
  npm install @storybook/native-devices@1.0.5-canary.34.459.0
  npm install @storybook/native-types@1.0.5-canary.34.459.0
  npm install @storybook/native@1.0.5-canary.34.459.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@1.0.5-canary.34.459.0
  yarn add @storybook/native-android-material-example@1.0.5-canary.34.459.0
  yarn add @storybook/native-controls-example@1.0.5-canary.34.459.0
  yarn add @storybook/native-flutter-example@1.0.5-canary.34.459.0
  yarn add @storybook/native-ios-example-deep-link@1.0.5-canary.34.459.0
  yarn add @storybook/native-ios-example@1.0.5-canary.34.459.0
  yarn add @storybook/appetize-utils@1.0.5-canary.34.459.0
  yarn add @storybook/native-addon@1.0.5-canary.34.459.0
  yarn add @storybook/native-components@1.0.5-canary.34.459.0
  yarn add @storybook/native-devices@1.0.5-canary.34.459.0
  yarn add @storybook/native-types@1.0.5-canary.34.459.0
  yarn add @storybook/native@1.0.5-canary.34.459.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
