### PR TITLE
Add debounce for deep link navigation

### DIFF
--- a/packages/native-components/package.json
+++ b/packages/native-components/package.json
@@ -18,6 +18,8 @@
     "@storybook/appetize-utils": "link:../appetize-utils",
     "@storybook/native-devices": "link:../native-devices",
     "@storybook/native-types": "link:../native-types",
+    "@types/lodash.debounce": "^4.0.6",
+    "lodash.debounce": "^4.0.8",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/packages/native-components/src/index.ts
+++ b/packages/native-components/src/index.ts
@@ -1,1 +1,2 @@
 export { default as EmulatorRenderer } from "./EmulatorRenderer";
+export { default as DeepLinkRenderer } from "./DeepLinkRenderer";

--- a/packages/native-components/src/types.ts
+++ b/packages/native-components/src/types.ts
@@ -23,3 +23,10 @@ export interface RendererProps {
      */
     knobs?: Record<string, any>;
 }
+
+export interface DeepLinkRendererProps extends RendererProps {
+    /**
+     * Delay in milliseconds before a new URL is sent to your mobile application.
+     */
+    debounceDelay?: number;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2629,7 +2629,7 @@
     util-deprecate "^1.0.2"
 
 "@storybook/appetize-utils@link:packages/appetize-utils":
-  version "1.0.4"
+  version "1.0.5"
 
 "@storybook/channel-postmessage@6.1.11":
   version "6.1.11"
@@ -2833,7 +2833,7 @@
     lodash "^4.17.15"
 
 "@storybook/native-addon@link:packages/native-addon":
-  version "1.0.4"
+  version "1.0.5"
   dependencies:
     "@storybook/addons" "^6.0.6"
     "@storybook/api" "^6.0.6"
@@ -2847,26 +2847,27 @@
     react-dom "^16.13.1"
 
 "@storybook/native-components@link:packages/native-components":
-  version "1.0.4"
+  version "1.0.5"
   dependencies:
     "@storybook/appetize-utils" "link:packages/appetize-utils"
     "@storybook/native-devices" "link:packages/native-devices"
     "@storybook/native-types" "link:packages/native-types"
+    lodash.debounce "^4.0.8"
     react "^16.13.1"
     react-dom "^16.13.1"
 
 "@storybook/native-devices@link:packages/native-devices":
-  version "1.0.4"
+  version "1.0.5"
   dependencies:
     "@storybook/native-types" "link:packages/native-types"
     react "^16.13.1"
     react-dom "^16.13.1"
 
 "@storybook/native-types@link:packages/native-types":
-  version "1.0.4"
+  version "1.0.5"
 
 "@storybook/native@link:packages/native":
-  version "1.0.4"
+  version "1.0.5"
   dependencies:
     "@storybook/addon-controls" "^6.0.6"
     "@storybook/addon-docs" "^6.0.6"
@@ -3129,6 +3130,18 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/lodash.debounce@^4.0.6":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz#c5a2326cd3efc46566c47e4c0aa248dc0ee57d60"
+  integrity sha1-xaIybNPvxGVmxH5MCqJI3A7lfWA=
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha1-/iRjLnm3rePxMoka//hsql5c4Ag=
 
 "@types/lodash@^4.14.159":
   version "4.14.164"
@@ -9295,6 +9308,11 @@ lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
 lodash.get@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.6-canary.35.469.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@1.0.6-canary.35.469.0
  npm install @storybook/native-android-material-example@1.0.6-canary.35.469.0
  npm install @storybook/native-controls-example@1.0.6-canary.35.469.0
  npm install @storybook/native-flutter-example@1.0.6-canary.35.469.0
  npm install @storybook/native-ios-example-deep-link@1.0.6-canary.35.469.0
  npm install @storybook/native-ios-example@1.0.6-canary.35.469.0
  npm install @storybook/appetize-utils@1.0.6-canary.35.469.0
  npm install @storybook/native-addon@1.0.6-canary.35.469.0
  npm install @storybook/native-components@1.0.6-canary.35.469.0
  npm install @storybook/native-devices@1.0.6-canary.35.469.0
  npm install @storybook/native-types@1.0.6-canary.35.469.0
  npm install @storybook/native@1.0.6-canary.35.469.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@1.0.6-canary.35.469.0
  yarn add @storybook/native-android-material-example@1.0.6-canary.35.469.0
  yarn add @storybook/native-controls-example@1.0.6-canary.35.469.0
  yarn add @storybook/native-flutter-example@1.0.6-canary.35.469.0
  yarn add @storybook/native-ios-example-deep-link@1.0.6-canary.35.469.0
  yarn add @storybook/native-ios-example@1.0.6-canary.35.469.0
  yarn add @storybook/appetize-utils@1.0.6-canary.35.469.0
  yarn add @storybook/native-addon@1.0.6-canary.35.469.0
  yarn add @storybook/native-components@1.0.6-canary.35.469.0
  yarn add @storybook/native-devices@1.0.6-canary.35.469.0
  yarn add @storybook/native-types@1.0.6-canary.35.469.0
  yarn add @storybook/native@1.0.6-canary.35.469.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
