### PR TITLE
Make debounce delay last across stories

### DIFF
--- a/packages/appetize-utils/package.json
+++ b/packages/appetize-utils/package.json
@@ -18,5 +18,9 @@
   "gitHead": "0f52a30495259d2b515e3a23cd516553894a4b30",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@types/lodash.debounce": "^4.0.6",
+    "lodash.debounce": "^4.0.8"
   }
 }

--- a/packages/appetize-utils/src/openDeepLink.ts
+++ b/packages/appetize-utils/src/openDeepLink.ts
@@ -1,13 +1,26 @@
+import debounce from "lodash.debounce";
 import { loadUrl } from "./iframeUtils";
 import { sendMessage } from "./sessionUtils";
 
-export const openDeepLink = (
+const undebouncedOpenDeepLink = (
     appetizeUrl: string,
     deepLinkUrl: string,
-    storyParams: Record<any, any>
+    storyParams: Record<string, any>
 ) => {
     loadUrl(appetizeUrl);
     const qsParams = new URLSearchParams(storyParams).toString();
     const newAppUrl = `${deepLinkUrl}?${qsParams}`;
     sendMessage({ type: "url", value: newAppUrl }, true);
 };
+
+export type OpenDeepLinkHandler = typeof undebouncedOpenDeepLink;
+export const openDeepLink: OpenDeepLinkHandler = debounce(
+    (
+        appetizeUrl: string,
+        deepLinkUrl: string,
+        storyParams: Record<string, any>
+    ) => {
+        undebouncedOpenDeepLink(appetizeUrl, deepLinkUrl, storyParams);
+    },
+    400
+);

--- a/packages/native-components/package.json
+++ b/packages/native-components/package.json
@@ -18,8 +18,6 @@
     "@storybook/appetize-utils": "link:../appetize-utils",
     "@storybook/native-devices": "link:../native-devices",
     "@storybook/native-types": "link:../native-types",
-    "@types/lodash.debounce": "^4.0.6",
-    "lodash.debounce": "^4.0.8",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/packages/native-components/src/DeepLinkRenderer.tsx
+++ b/packages/native-components/src/DeepLinkRenderer.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { getAppetizeUrl, openDeepLink } from "@storybook/appetize-utils";
 import { useDevice } from "@storybook/native-devices";
-import debounce from "lodash.debounce";
 
 import { DeepLinkRendererProps } from "./types";
 
@@ -12,7 +11,7 @@ export default (props: DeepLinkRendererProps): React.ReactElement => {
         knobs,
         storyParams,
         deepLinkBaseUrl,
-        debounceDelay = 400
+        debounceDelay
     } = props;
     const device = useDevice(platform);
 
@@ -20,19 +19,11 @@ export default (props: DeepLinkRendererProps): React.ReactElement => {
         throw new Error("No deep link base url was specified");
     }
 
-    const navigate = React.useCallback(
-        debounce(
-            (
-                appetizeUrl: string,
-                baseUrl: string,
-                params: Record<string, any>
-            ) => {
-                openDeepLink(appetizeUrl, baseUrl, params);
-            },
-            debounceDelay
-        ),
-        [debounceDelay]
-    );
+    if (debounceDelay) {
+        console.warn(
+            `The debounceDelay prop is deprecated and will be removed in the next version of Storybook Native`
+        );
+    }
 
     const storyParamsWithExtras = { ...storyParams, ...knobs };
     React.useEffect(() => {
@@ -44,7 +35,7 @@ export default (props: DeepLinkRendererProps): React.ReactElement => {
             apiKey
         );
 
-        navigate(appetizeUrl, deepLinkBaseUrl, storyParamsWithExtras);
+        openDeepLink(appetizeUrl, deepLinkBaseUrl, storyParamsWithExtras);
     }, [
         device,
         JSON.stringify(storyParamsWithExtras),

--- a/packages/native-components/src/DeepLinkRenderer.tsx
+++ b/packages/native-components/src/DeepLinkRenderer.tsx
@@ -21,7 +21,7 @@ export default (props: DeepLinkRendererProps): React.ReactElement => {
 
     if (debounceDelay) {
         console.warn(
-            `The debounceDelay prop is deprecated and will be removed in the next version of Storybook Native`
+            `The debounceDelay prop is deprecated and will be removed in the next major version of Storybook Native`
         );
     }
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.1.4-canary.42.530.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@1.1.4-canary.42.530.0
  npm install @storybook/native-android-material-example@1.1.4-canary.42.530.0
  npm install @storybook/native-controls-example@1.1.4-canary.42.530.0
  npm install @storybook/native-flutter-example@1.1.4-canary.42.530.0
  npm install @storybook/native-ios-example-deep-link@1.1.4-canary.42.530.0
  npm install @storybook/native-ios-example@1.1.4-canary.42.530.0
  npm install @storybook/appetize-utils@1.1.4-canary.42.530.0
  npm install @storybook/native-addon@1.1.4-canary.42.530.0
  npm install @storybook/native-components@1.1.4-canary.42.530.0
  npm install @storybook/native-devices@1.1.4-canary.42.530.0
  npm install @storybook/native-types@1.1.4-canary.42.530.0
  npm install @storybook/native@1.1.4-canary.42.530.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@1.1.4-canary.42.530.0
  yarn add @storybook/native-android-material-example@1.1.4-canary.42.530.0
  yarn add @storybook/native-controls-example@1.1.4-canary.42.530.0
  yarn add @storybook/native-flutter-example@1.1.4-canary.42.530.0
  yarn add @storybook/native-ios-example-deep-link@1.1.4-canary.42.530.0
  yarn add @storybook/native-ios-example@1.1.4-canary.42.530.0
  yarn add @storybook/appetize-utils@1.1.4-canary.42.530.0
  yarn add @storybook/native-addon@1.1.4-canary.42.530.0
  yarn add @storybook/native-components@1.1.4-canary.42.530.0
  yarn add @storybook/native-devices@1.1.4-canary.42.530.0
  yarn add @storybook/native-types@1.1.4-canary.42.530.0
  yarn add @storybook/native@1.1.4-canary.42.530.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
