### PR TITLE
Add better rotation icons

### DIFF
--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -16,6 +16,9 @@
     "build": "tsc -b"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.35",
+    "@fortawesome/free-solid-svg-icons": "^5.15.3",
+    "@fortawesome/react-fontawesome": "^0.1.14",
     "@storybook/addons": "^6.0.6",
     "@storybook/api": "^6.0.6",
     "@storybook/client-api": "^6.0.6",

--- a/packages/addon/src/register.tsx
+++ b/packages/addon/src/register.tsx
@@ -4,6 +4,8 @@ import { Icons, IconButton } from "@storybook/components";
 import { ACTION_EVENT_NAME } from "@storybook/native-controllers";
 import { DeepLinksContainer } from "@storybook/deep-link-logger";
 import { EmulatorActions } from "@storybook/native-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faUndo, faRedo } from "@fortawesome/free-solid-svg-icons";
 
 import { ADDON_ID, DEEP_LINKS_PARAM_KEY } from "./constants";
 import DeviceSelector from "./components/DeviceSelector";
@@ -29,7 +31,7 @@ addons.register(ADDON_ID, (api) => {
         title: "Rotate left",
         render: () => (
             <IconButton title="Rotate left" onClick={rotateLeft}>
-                <Icons icon="arrowleft" />
+                <FontAwesomeIcon size="sm" icon={faUndo} />
             </IconButton>
         )
     });
@@ -39,7 +41,7 @@ addons.register(ADDON_ID, (api) => {
         title: "Rotate right",
         render: () => (
             <IconButton title="Rotate right" onClick={rotateRight}>
-                <Icons icon="arrowright" />
+                <FontAwesomeIcon size="sm" icon={faRedo} />
             </IconButton>
         )
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,6 +1413,32 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fortawesome/fontawesome-common-types@^0.2.35":
+  version "0.2.35"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz#01dd3d054da07a00b764d78748df20daf2b317e9"
+  integrity sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==
+
+"@fortawesome/fontawesome-svg-core@^1.2.35":
+  version "1.2.35"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz#85aea8c25645fcec88d35f2eb1045c38d3e65cff"
+  integrity sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.35"
+
+"@fortawesome/free-solid-svg-icons@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz#52eebe354f60dc77e0bde934ffc5c75ffd04f9d8"
+  integrity sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.35"
+
+"@fortawesome/react-fontawesome@^0.1.14":
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz#bf28875c3935b69ce2dc620e1060b217a47f64ca"
+  integrity sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==
+  dependencies:
+    prop-types "^15.7.2"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -2938,7 +2964,7 @@
     lodash "^4.17.15"
 
 "@storybook/deep-link-logger@link:packages/deep-link-logger":
-  version "2.0.1"
+  version "2.0.2"
   dependencies:
     "@storybook/addons" "^6.0.6"
     "@storybook/api" "^6.0.6"
@@ -2949,7 +2975,7 @@
     react-dom "^16.13.1"
 
 "@storybook/native-addon@link:packages/addon":
-  version "2.0.1"
+  version "2.0.2"
   dependencies:
     "@storybook/addons" "^6.0.6"
     "@storybook/api" "^6.0.6"
@@ -2966,7 +2992,7 @@
     react-dom "^16.13.1"
 
 "@storybook/native-components@link:packages/native-components":
-  version "2.0.1"
+  version "2.0.2"
   dependencies:
     "@storybook/addons" "^6.0.6"
     "@storybook/components" "^6.0.6"
@@ -2978,36 +3004,36 @@
     react-redux "^7.2.2"
 
 "@storybook/native-controllers@link:packages/controllers":
-  version "2.0.1"
+  version "2.0.2"
   dependencies:
     "@storybook/deep-link-logger" "link:packages/deep-link-logger"
     "@storybook/native-types" "link:packages/types"
     "@types/lodash.debounce" "^4.0.6"
     axios "^0.21.1"
-    lodash.debounce "^4.0.8"
+    lodash "^4.17.21"
     react-redux "^7.2.2"
     redux "^4.0.5"
     redux-thunk "^2.3.0"
 
 "@storybook/native-dev-middleware@link:packages/dev-middleware":
-  version "2.0.1"
+  version "2.0.2"
   dependencies:
     "@storybook/native-types" "link:packages/types"
     "@types/express" "^4.17.11"
     express "^4.17.0"
 
 "@storybook/native-devices@link:packages/devices":
-  version "2.0.1"
+  version "2.0.2"
   dependencies:
     "@storybook/native-types" "link:packages/types"
     react "^16.13.1"
     react-dom "^16.13.1"
 
 "@storybook/native-types@link:packages/types":
-  version "2.0.1"
+  version "2.0.2"
 
 "@storybook/native@link:packages/native":
-  version "2.0.1"
+  version "2.0.2"
   dependencies:
     "@storybook/addon-controls" "^6.0.6"
     "@storybook/addon-docs" "^6.0.6"


### PR DESCRIPTION
Closes #56 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.1.1-canary.61.677.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@2.1.1-canary.61.677.0
  npm install @storybook/native-controls-example@2.1.1-canary.61.677.0
  npm install @storybook/native-cross-platform-example@2.1.1-canary.61.677.0
  npm install @storybook/native-flutter-example@2.1.1-canary.61.677.0
  npm install @storybook/native-ios-example-deep-link@2.1.1-canary.61.677.0
  npm install @storybook/native-addon@2.1.1-canary.61.677.0
  npm install @storybook/native-controllers@2.1.1-canary.61.677.0
  npm install @storybook/deep-link-logger@2.1.1-canary.61.677.0
  npm install @storybook/native-dev-middleware@2.1.1-canary.61.677.0
  npm install @storybook/native-devices@2.1.1-canary.61.677.0
  npm install @storybook/native-components@2.1.1-canary.61.677.0
  npm install @storybook/native@2.1.1-canary.61.677.0
  npm install @storybook/native-types@2.1.1-canary.61.677.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@2.1.1-canary.61.677.0
  yarn add @storybook/native-controls-example@2.1.1-canary.61.677.0
  yarn add @storybook/native-cross-platform-example@2.1.1-canary.61.677.0
  yarn add @storybook/native-flutter-example@2.1.1-canary.61.677.0
  yarn add @storybook/native-ios-example-deep-link@2.1.1-canary.61.677.0
  yarn add @storybook/native-addon@2.1.1-canary.61.677.0
  yarn add @storybook/native-controllers@2.1.1-canary.61.677.0
  yarn add @storybook/deep-link-logger@2.1.1-canary.61.677.0
  yarn add @storybook/native-dev-middleware@2.1.1-canary.61.677.0
  yarn add @storybook/native-devices@2.1.1-canary.61.677.0
  yarn add @storybook/native-components@2.1.1-canary.61.677.0
  yarn add @storybook/native@2.1.1-canary.61.677.0
  yarn add @storybook/native-types@2.1.1-canary.61.677.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
