### PR TITLE
make appetize base url configurable for use with subdomains

### DIFF
--- a/packages/controllers/src/utils/getAppetizeUrl.ts
+++ b/packages/controllers/src/utils/getAppetizeUrl.ts
@@ -3,7 +3,8 @@ import type { EmulatorConfig } from "@storybook/native-types";
 export const getAppetizeUrl = ({
     launchArgs,
     settings,
-    apiKey
+    apiKey,
+    baseUrl = "https://appetize.io"
 }: EmulatorConfig) => {
     if (!apiKey) {
         throw new Error("No appetize API key was specified");
@@ -18,7 +19,7 @@ export const getAppetizeUrl = ({
         options.params = JSON.stringify(launchArgs);
     }
 
-    const urlWithoutParams = `https://appetize.io/embed/${apiKey}`;
+    const urlWithoutParams = `${baseUrl}/embed/${apiKey}`;
     // @ts-ignore
     const qsParams = new URLSearchParams(options).toString();
 

--- a/packages/native-components/src/renderers/DeepLinkRenderer.tsx
+++ b/packages/native-components/src/renderers/DeepLinkRenderer.tsx
@@ -23,6 +23,7 @@ export default (props: DeepLinkRendererProps): React.ReactElement => {
         extraParams,
         storyParams,
         deepLinkBaseUrl,
+        appetizeBaseUrl,
         context
     } = props;
 
@@ -52,9 +53,10 @@ export default (props: DeepLinkRendererProps): React.ReactElement => {
             settings: {
                 device
             },
-            platform
+            platform,
+            baseUrl: appetizeBaseUrl
         });
-    }, [device, apiKey, context, platform]);
+    }, [device, apiKey, context, platform, appetizeBaseUrl]);
 
     const storyParamsWithExtras = { ...storyParams, ...extraParams };
     React.useEffect(() => {
@@ -69,7 +71,8 @@ export default (props: DeepLinkRendererProps): React.ReactElement => {
         JSON.stringify(storyParamsWithExtras),
         deepLinkBaseUrl,
         apiKey,
-        context
+        context,
+        appetizeBaseUrl
     ]);
 
     React.useEffect(() => {

--- a/packages/native-components/src/renderers/LaunchParamsRenderer.tsx
+++ b/packages/native-components/src/renderers/LaunchParamsRenderer.tsx
@@ -9,7 +9,8 @@ import { addons } from "@storybook/addons";
 import { RendererProps } from "../types";
 
 export default (props: RendererProps): React.ReactElement => {
-    const { apiKey, platform, extraParams, storyParams } = props;
+    const { apiKey, platform, extraParams, storyParams, appetizeBaseUrl } =
+        props;
     const iframeRef = React.useRef<HTMLIFrameElement>(null);
     const device = useDevice(platform);
 
@@ -31,7 +32,8 @@ export default (props: RendererProps): React.ReactElement => {
             device
         },
         launchArgs: storyParamsWithExtras,
-        platform
+        platform,
+        baseUrl: appetizeBaseUrl
     });
     return (
         <iframe

--- a/packages/native-components/src/types.ts
+++ b/packages/native-components/src/types.ts
@@ -22,6 +22,13 @@ export interface RendererProps {
      * This prop is provided entirely for convenience
      */
     extraParams?: Record<string, any>;
+
+    /**
+     * An alternate base URL to use for Appetize, if a custom subdomain is required
+     *
+     * Example: "https://mycompany.appetize.io"
+     */
+    appetizeBaseUrl?: string;
 }
 
 export interface DeepLinkRendererProps extends RendererProps {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -12,6 +12,9 @@ export interface EmulatorConfig {
 
     apiKey?: string;
     launchArgs?: Record<string, any>;
+
+    /** The base URL to use for appetize */
+    baseUrl?: string;
 }
 
 export enum EmulatorActions {


### PR DESCRIPTION
Adds an `appetizeBaseUrl` parameter to the renderers that passes through to set the base url for the appetize embed URL

For use cases where there is a custom subdomain for appetize, rather than the public URL
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.1-canary.67.725.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@2.2.1-canary.67.725.0
  npm install @storybook/native-controls-example@2.2.1-canary.67.725.0
  npm install @storybook/native-cross-platform-example@2.2.1-canary.67.725.0
  npm install @storybook/native-flutter-example@2.2.1-canary.67.725.0
  npm install @storybook/native-ios-example-deep-link@2.2.1-canary.67.725.0
  npm install @storybook/native-addon@2.2.1-canary.67.725.0
  npm install @storybook/native-controllers@2.2.1-canary.67.725.0
  npm install @storybook/deep-link-logger@2.2.1-canary.67.725.0
  npm install @storybook/native-dev-middleware@2.2.1-canary.67.725.0
  npm install @storybook/native-devices@2.2.1-canary.67.725.0
  npm install @storybook/native-components@2.2.1-canary.67.725.0
  npm install @storybook/native@2.2.1-canary.67.725.0
  npm install @storybook/native-types@2.2.1-canary.67.725.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@2.2.1-canary.67.725.0
  yarn add @storybook/native-controls-example@2.2.1-canary.67.725.0
  yarn add @storybook/native-cross-platform-example@2.2.1-canary.67.725.0
  yarn add @storybook/native-flutter-example@2.2.1-canary.67.725.0
  yarn add @storybook/native-ios-example-deep-link@2.2.1-canary.67.725.0
  yarn add @storybook/native-addon@2.2.1-canary.67.725.0
  yarn add @storybook/native-controllers@2.2.1-canary.67.725.0
  yarn add @storybook/deep-link-logger@2.2.1-canary.67.725.0
  yarn add @storybook/native-dev-middleware@2.2.1-canary.67.725.0
  yarn add @storybook/native-devices@2.2.1-canary.67.725.0
  yarn add @storybook/native-components@2.2.1-canary.67.725.0
  yarn add @storybook/native@2.2.1-canary.67.725.0
  yarn add @storybook/native-types@2.2.1-canary.67.725.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
