### PR TITLE
Add newer devices from appetize

### DIFF
--- a/packages/devices/src/getDevices.ts
+++ b/packages/devices/src/getDevices.ts
@@ -19,6 +19,8 @@ export const getDevices = (platform: Platform): string[] => {
             "nexus9",
             "pixel4",
             "pixel4xl",
+            "pixel6",
+            "pixel6pro",
             "galaxytabs7"
         ];
     }
@@ -30,7 +32,11 @@ export const getDevices = (platform: Platform): string[] => {
             "ipadair2",
             "iphone9",
             "iphone11pro",
-            "iphone11promax"
+            "iphone11promax",
+            "iphone12",
+            "iphone12mini",
+            "iphone12pro",
+            "iphone12promax"
         ];
     }
 


### PR DESCRIPTION
Add newer devices that appetize supports. These devices also use newer os versions, so apps with minimum os versions that are newer can use these.

Also, apologies if this doesn't follow a specific PR template or anything, looked around but couldn't find one so please let me know if there is anything else this needs.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.3-canary.69.745.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@2.2.3-canary.69.745.0
  npm install @storybook/native-controls-example@2.2.3-canary.69.745.0
  npm install @storybook/native-cross-platform-example@2.2.3-canary.69.745.0
  npm install @storybook/native-flutter-example@2.2.3-canary.69.745.0
  npm install @storybook/native-ios-example-deep-link@2.2.3-canary.69.745.0
  npm install @storybook/native-addon@2.2.3-canary.69.745.0
  npm install @storybook/native-controllers@2.2.3-canary.69.745.0
  npm install @storybook/deep-link-logger@2.2.3-canary.69.745.0
  npm install @storybook/native-dev-middleware@2.2.3-canary.69.745.0
  npm install @storybook/native-devices@2.2.3-canary.69.745.0
  npm install @storybook/native-components@2.2.3-canary.69.745.0
  npm install @storybook/native@2.2.3-canary.69.745.0
  npm install @storybook/native-types@2.2.3-canary.69.745.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@2.2.3-canary.69.745.0
  yarn add @storybook/native-controls-example@2.2.3-canary.69.745.0
  yarn add @storybook/native-cross-platform-example@2.2.3-canary.69.745.0
  yarn add @storybook/native-flutter-example@2.2.3-canary.69.745.0
  yarn add @storybook/native-ios-example-deep-link@2.2.3-canary.69.745.0
  yarn add @storybook/native-addon@2.2.3-canary.69.745.0
  yarn add @storybook/native-controllers@2.2.3-canary.69.745.0
  yarn add @storybook/deep-link-logger@2.2.3-canary.69.745.0
  yarn add @storybook/native-dev-middleware@2.2.3-canary.69.745.0
  yarn add @storybook/native-devices@2.2.3-canary.69.745.0
  yarn add @storybook/native-components@2.2.3-canary.69.745.0
  yarn add @storybook/native@2.2.3-canary.69.745.0
  yarn add @storybook/native-types@2.2.3-canary.69.745.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
