### PR TITLE
Change default iOS device to iPhone 12

### DIFF
--- a/packages/devices/src/getDevices.ts
+++ b/packages/devices/src/getDevices.ts
@@ -5,7 +5,7 @@ export const getDefaultDevice = (platform: Platform): string => {
         return "nexus5";
     }
     if (platform === "ios") {
-        return "iphone9";
+        return "iphone12";
     }
 
     throw new Error(`No device for platform: ${platform}`);


### PR DESCRIPTION
Building off of this PR: https://github.com/storybookjs/native/pull/69, I'd like to set the default iOS emulator device to the iPhone 12 because my storybook iOS components are compatible with iOS 14+. The iPhone 12's are the only devices on the device list that default to iOS 14.

Since there isn't really a way to switch emulator OS versions right now, having the emulator default to an iPhone 12 would be much more convenient to users viewing mobile components that support the latest iOS versions (instead of having to instruct them to switch devices using the device menu each time they view a new component). 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.4-canary.70.754.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@2.2.4-canary.70.754.0
  npm install @storybook/native-controls-example@2.2.4-canary.70.754.0
  npm install @storybook/native-cross-platform-example@2.2.4-canary.70.754.0
  npm install @storybook/native-flutter-example@2.2.4-canary.70.754.0
  npm install @storybook/native-ios-example-deep-link@2.2.4-canary.70.754.0
  npm install @storybook/native-addon@2.2.4-canary.70.754.0
  npm install @storybook/native-controllers@2.2.4-canary.70.754.0
  npm install @storybook/deep-link-logger@2.2.4-canary.70.754.0
  npm install @storybook/native-dev-middleware@2.2.4-canary.70.754.0
  npm install @storybook/native-devices@2.2.4-canary.70.754.0
  npm install @storybook/native-components@2.2.4-canary.70.754.0
  npm install @storybook/native@2.2.4-canary.70.754.0
  npm install @storybook/native-types@2.2.4-canary.70.754.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@2.2.4-canary.70.754.0
  yarn add @storybook/native-controls-example@2.2.4-canary.70.754.0
  yarn add @storybook/native-cross-platform-example@2.2.4-canary.70.754.0
  yarn add @storybook/native-flutter-example@2.2.4-canary.70.754.0
  yarn add @storybook/native-ios-example-deep-link@2.2.4-canary.70.754.0
  yarn add @storybook/native-addon@2.2.4-canary.70.754.0
  yarn add @storybook/native-controllers@2.2.4-canary.70.754.0
  yarn add @storybook/deep-link-logger@2.2.4-canary.70.754.0
  yarn add @storybook/native-dev-middleware@2.2.4-canary.70.754.0
  yarn add @storybook/native-devices@2.2.4-canary.70.754.0
  yarn add @storybook/native-components@2.2.4-canary.70.754.0
  yarn add @storybook/native@2.2.4-canary.70.754.0
  yarn add @storybook/native-types@2.2.4-canary.70.754.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
