### PR TITLE
Support range control

### DIFF
--- a/examples/android-material-ui/generate.js
+++ b/examples/android-material-ui/generate.js
@@ -14,7 +14,7 @@ const components = [
                 max: 1,
                 increment: 0.2
             },
-            progressSlider: {
+            size: {
                 type: 'range',
                 min: 0,
                 max: 1,

--- a/examples/android-material-ui/generate.js
+++ b/examples/android-material-ui/generate.js
@@ -13,6 +13,12 @@ const components = [
                 min: 0,
                 max: 1,
                 increment: 0.2
+            },
+            progressSlider: {
+                type: 'range',
+                min: 0,
+                max: 1,
+                increment: 0.2
             }
         },
         docs: "https://raw.githubusercontent.com/material-components/material-components-android/master/docs/components/Button.md"

--- a/packages/native/categoryControl.template
+++ b/packages/native/categoryControl.template
@@ -2,14 +2,14 @@ import React from 'react';
 import { Description } from '@storybook/addon-docs/blocks';
 import { EmulatorRenderer } from '@storybook/native-components';
 
-export default { 
+export default {
     title: '<%= category %>',
     argTypes: {
         <% _.each(controls, function(control){ %>
         <% if (control[1].hasOwnProperty('min') && control[1].hasOwnProperty('max')) { %>
         <%= control[0] %>: {
             control: {
-                type: 'number',
+                type: '<%= control[1].type || "number" %>',
                 min: <%= control[1].min %>,
                 max: <%= control[1].max %>,
                 step: <%= control[1].increment %>


### PR DESCRIPTION
## Describe your changes

Support `type` attribute for controls to be able to use `range` value 

## UI changes

![Screen Recording 2022-04-09 at 11 58 27 AM](https://user-images.githubusercontent.com/22000308/162555493-773c861c-6eed-454f-89cf-b7e0b1b64e0d.gif)

## Testing

* backward compatible  with `number`
* check button story in android-material-ui example

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.5-canary.71.764.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@2.2.5-canary.71.764.0
  npm install @storybook/native-controls-example@2.2.5-canary.71.764.0
  npm install @storybook/native-cross-platform-example@2.2.5-canary.71.764.0
  npm install @storybook/native-flutter-example@2.2.5-canary.71.764.0
  npm install @storybook/native-ios-example-deep-link@2.2.5-canary.71.764.0
  npm install @storybook/native-addon@2.2.5-canary.71.764.0
  npm install @storybook/native-controllers@2.2.5-canary.71.764.0
  npm install @storybook/deep-link-logger@2.2.5-canary.71.764.0
  npm install @storybook/native-dev-middleware@2.2.5-canary.71.764.0
  npm install @storybook/native-devices@2.2.5-canary.71.764.0
  npm install @storybook/native-components@2.2.5-canary.71.764.0
  npm install @storybook/native@2.2.5-canary.71.764.0
  npm install @storybook/native-types@2.2.5-canary.71.764.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@2.2.5-canary.71.764.0
  yarn add @storybook/native-controls-example@2.2.5-canary.71.764.0
  yarn add @storybook/native-cross-platform-example@2.2.5-canary.71.764.0
  yarn add @storybook/native-flutter-example@2.2.5-canary.71.764.0
  yarn add @storybook/native-ios-example-deep-link@2.2.5-canary.71.764.0
  yarn add @storybook/native-addon@2.2.5-canary.71.764.0
  yarn add @storybook/native-controllers@2.2.5-canary.71.764.0
  yarn add @storybook/deep-link-logger@2.2.5-canary.71.764.0
  yarn add @storybook/native-dev-middleware@2.2.5-canary.71.764.0
  yarn add @storybook/native-devices@2.2.5-canary.71.764.0
  yarn add @storybook/native-components@2.2.5-canary.71.764.0
  yarn add @storybook/native@2.2.5-canary.71.764.0
  yarn add @storybook/native-types@2.2.5-canary.71.764.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
