### PR TITLE
add updated devices and OS version options

### DIFF
--- a/packages/devices/src/getDevices.ts
+++ b/packages/devices/src/getDevices.ts
@@ -5,7 +5,7 @@ export const getDefaultDevice = (platform: Platform): string => {
         return "nexus5";
     }
     if (platform === "ios") {
-        return "iphone12";
+        return "iphone14pro";
     }
 
     throw new Error(`No device for platform: ${platform}`);
@@ -36,7 +36,9 @@ export const getDevices = (platform: Platform): string[] => {
             "iphone12",
             "iphone12mini",
             "iphone12pro",
-            "iphone12promax"
+            "iphone12promax",
+            "iphone14pro",
+            "iphone14promax"
         ];
     }
 
@@ -48,7 +50,7 @@ export const getDefaultOsVersion = (platform: Platform): string => {
         return "11.0";
     }
     if (platform === "ios") {
-        return "15.0";
+        return "16.0";
     }
 
     throw new Error(`No osVersion for platform: ${platform}`);
@@ -56,10 +58,20 @@ export const getDefaultOsVersion = (platform: Platform): string => {
 
 export const getOsVersions = (platform: Platform): string[] => {
     if (platform === "android") {
-        return ["4.4", "5.1", "6.0", "7.1", "8.1", "9.0", "10.0", "11.0"];
+        return [
+            "4.4",
+            "5.1",
+            "6.0",
+            "7.1",
+            "8.1",
+            "9.0",
+            "10.0",
+            "11.0",
+            "12.0"
+        ];
     }
     if (platform === "ios") {
-        return ["11.4", "12.4", "13.7", "14.5", "15.0"];
+        return ["11.4", "12.4", "13.7", "14.5", "15.5", "16.0"];
     }
 
     throw new Error(`No osVersions for platform: ${platform}`);


### PR DESCRIPTION
- Added iOS 16 and Android 12 options
- Changed `15.0` to `15.5` as appetize does not have `15.0` anymore since newer versions of 15 were released
- Added iPhone 14 variants that appetize supports
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.2.8-canary.76.802.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@2.2.8-canary.76.802.0
  npm install @storybook/native-controls-example@2.2.8-canary.76.802.0
  npm install @storybook/native-cross-platform-example@2.2.8-canary.76.802.0
  npm install @storybook/native-flutter-example@2.2.8-canary.76.802.0
  npm install @storybook/native-ios-example-deep-link@2.2.8-canary.76.802.0
  npm install @storybook/native-addon@2.2.8-canary.76.802.0
  npm install @storybook/native-controllers@2.2.8-canary.76.802.0
  npm install @storybook/deep-link-logger@2.2.8-canary.76.802.0
  npm install @storybook/native-dev-middleware@2.2.8-canary.76.802.0
  npm install @storybook/native-devices@2.2.8-canary.76.802.0
  npm install @storybook/native-components@2.2.8-canary.76.802.0
  npm install @storybook/native@2.2.8-canary.76.802.0
  npm install @storybook/native-types@2.2.8-canary.76.802.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@2.2.8-canary.76.802.0
  yarn add @storybook/native-controls-example@2.2.8-canary.76.802.0
  yarn add @storybook/native-cross-platform-example@2.2.8-canary.76.802.0
  yarn add @storybook/native-flutter-example@2.2.8-canary.76.802.0
  yarn add @storybook/native-ios-example-deep-link@2.2.8-canary.76.802.0
  yarn add @storybook/native-addon@2.2.8-canary.76.802.0
  yarn add @storybook/native-controllers@2.2.8-canary.76.802.0
  yarn add @storybook/deep-link-logger@2.2.8-canary.76.802.0
  yarn add @storybook/native-dev-middleware@2.2.8-canary.76.802.0
  yarn add @storybook/native-devices@2.2.8-canary.76.802.0
  yarn add @storybook/native-components@2.2.8-canary.76.802.0
  yarn add @storybook/native@2.2.8-canary.76.802.0
  yarn add @storybook/native-types@2.2.8-canary.76.802.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
