### PR TITLE
Update android defaults to more modern device/os

### DIFF
--- a/packages/devices/src/getDevices.ts
+++ b/packages/devices/src/getDevices.ts
@@ -2,7 +2,7 @@ import { Platform } from "@storybook/native-types";
 
 export const getDefaultDevice = (platform: Platform): string => {
     if (platform === "android") {
-        return "nexus5";
+        return "pixel4";
     }
     if (platform === "ios") {
         return "iphone15pro";
@@ -51,7 +51,7 @@ export const getDevices = (platform: Platform): string[] => {
 
 export const getDefaultOsVersion = (platform: Platform): string => {
     if (platform === "android") {
-        return "11.0";
+        return "13.0";
     }
     if (platform === "ios") {
         return "17.0";


### PR DESCRIPTION
Updating the android defaults for OS + Device to more modern versions. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.1.2-canary.95.985.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/native-android-material-deep-link-example@3.1.2-canary.95.985.0
  npm install @storybook/native-controls-example@3.1.2-canary.95.985.0
  npm install @storybook/native-cross-platform-example@3.1.2-canary.95.985.0
  npm install @storybook/native-flutter-example@3.1.2-canary.95.985.0
  npm install @storybook/native-ios-example-deep-link@3.1.2-canary.95.985.0
  npm install @storybook/native-addon@3.1.2-canary.95.985.0
  npm install @storybook/native-controllers@3.1.2-canary.95.985.0
  npm install @storybook/deep-link-logger@3.1.2-canary.95.985.0
  npm install @storybook/native-dev-middleware@3.1.2-canary.95.985.0
  npm install @storybook/native-devices@3.1.2-canary.95.985.0
  npm install @storybook/native-components@3.1.2-canary.95.985.0
  npm install @storybook/native@3.1.2-canary.95.985.0
  npm install @storybook/native-types@3.1.2-canary.95.985.0
  # or 
  yarn add @storybook/native-android-material-deep-link-example@3.1.2-canary.95.985.0
  yarn add @storybook/native-controls-example@3.1.2-canary.95.985.0
  yarn add @storybook/native-cross-platform-example@3.1.2-canary.95.985.0
  yarn add @storybook/native-flutter-example@3.1.2-canary.95.985.0
  yarn add @storybook/native-ios-example-deep-link@3.1.2-canary.95.985.0
  yarn add @storybook/native-addon@3.1.2-canary.95.985.0
  yarn add @storybook/native-controllers@3.1.2-canary.95.985.0
  yarn add @storybook/deep-link-logger@3.1.2-canary.95.985.0
  yarn add @storybook/native-dev-middleware@3.1.2-canary.95.985.0
  yarn add @storybook/native-devices@3.1.2-canary.95.985.0
  yarn add @storybook/native-components@3.1.2-canary.95.985.0
  yarn add @storybook/native@3.1.2-canary.95.985.0
  yarn add @storybook/native-types@3.1.2-canary.95.985.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
